### PR TITLE
ECS likes making strict checks, but in this case it'll break, if `""`…

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -51,7 +51,7 @@ class TwigExtension extends AbstractExtension
 
     public function geolocationDecodeJson($str): object
     {
-        if ($str === null) {
+        if (empty($str)) {
             return (object) [
                 'selected' => null,
                 'search' => null,


### PR DESCRIPTION
… is passed in.