### PR TITLE
Feature/add extra datas restrict geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ test:
     icon_one: "fa:home"
 ```
 
+Field can have autocompleteOptions key in order to set componentRestrictions for exemple
+
+```
+location:
+    type: geolocation
+    autocompleteOptions:
+        componentRestrictions:
+            country: 'us'
+```
+To see all options avalible, please refer you to [google documentation](https://developers.google.com/maps/documentation/javascript/geocoding#ComponentFiltering) 
+
 With that you can see the field in the backend:
 
 ![Backend Field](screenshots/backend-field-empty.png)

--- a/assets/geolocation/geolocation.js
+++ b/assets/geolocation/geolocation.js
@@ -289,6 +289,29 @@ GEOLOCATION.Field = ( function( $ ) {
 
   }
 
+  // Geocode
+  Field.prototype.geocodeLatLng = function(lat, lng) {
+    const geocoder = new google.maps.Geocoder();
+    const latlng = {
+      lat,
+      lng,
+    };
+
+    return new Promise(function(resolve, reject) {
+      geocoder.geocode({ location: latlng }, function(results, status) {
+        if (status === "OK") {
+          if (results[0]) {
+            resolve(results[0]);
+          } else {
+            reject();
+          }
+        } else {
+          reject();
+        }
+      })
+    })
+  }
+
   // exports
   return Field;
 }( $ ) );

--- a/assets/geolocation/geolocation.js
+++ b/assets/geolocation/geolocation.js
@@ -134,7 +134,33 @@ GEOLOCATION.Field = ( function( $ ) {
       let hidden_input_val = that.get_hidden_input_val();
       hidden_input_val.zoom = zoom;
 
-      that.$hidden_input.val( JSON.stringify( hidden_input_val ) );
+      // Geocoder
+      that.geocodeLatLng(parseFloat(hidden_input_val.lat), parseFloat(hidden_input_val.long))
+          .then((place) => {
+            hidden_input_val.zipCode = null;
+            hidden_input_val.city = null;
+            hidden_input_val.country = null;
+            for(const component of place.address_components) {
+              if(component.types.includes('postal_code')) {
+                hidden_input_val.zipCode = component.long_name;
+              }
+              if(component.types.includes('locality')) {
+                hidden_input_val.city = component.long_name;
+              }
+              if(component.types.includes('country')) {
+                hidden_input_val.country = component.long_name;
+              }
+            }
+            that.$hidden_input.val( JSON.stringify( hidden_input_val ) );
+          })
+          .catch((err) => {
+            hidden_input_val.zipCode = null;
+            hidden_input_val.city = null;
+            hidden_input_val.country = null;
+            that.$hidden_input.val( JSON.stringify( hidden_input_val ) );
+          })
+      ;
+
       that.updateGMapLatLong();
     } );
 

--- a/assets/geolocation/geolocation.js
+++ b/assets/geolocation/geolocation.js
@@ -175,8 +175,10 @@ GEOLOCATION.Field = ( function( $ ) {
       zoom: 13,
     } );
 
+    const autocompleteOptions = JSON.parse(that.$hidden_input[0].dataset.autocompleteOptions);
+
     const input = that.$wrapper.find( '.geolocation-field-search > input' )[0];
-    const autocomplete = new google.maps.places.Autocomplete( input );
+    const autocomplete = new google.maps.places.Autocomplete( input, autocompleteOptions );
     // Set the data fields to return when the user selects a place.
     autocomplete.setFields( ["geometry", "name", "formatted_address", "address_components"] );
     autocomplete.addListener( "place_changed", () => {

--- a/assets/geolocation/geolocation.js
+++ b/assets/geolocation/geolocation.js
@@ -178,7 +178,7 @@ GEOLOCATION.Field = ( function( $ ) {
     const input = that.$wrapper.find( '.geolocation-field-search > input' )[0];
     const autocomplete = new google.maps.places.Autocomplete( input );
     // Set the data fields to return when the user selects a place.
-    autocomplete.setFields( ["geometry", "name", "formatted_address"] );
+    autocomplete.setFields( ["geometry", "name", "formatted_address", "address_components"] );
     autocomplete.addListener( "place_changed", () => {
       const place = autocomplete.getPlace();
 
@@ -205,6 +205,22 @@ GEOLOCATION.Field = ( function( $ ) {
       hidden_input_val.search = place.formatted_address;
       hidden_input_val.lat = place.geometry.location.lat();
       hidden_input_val.long = place.geometry.location.lng();
+      hidden_input_val.zipCode = null;
+      hidden_input_val.city = null;
+      hidden_input_val.country = null;
+
+      for(const component of place.address_components) {
+        if(component.types.includes('postal_code')) {
+          hidden_input_val.zipCode = component.long_name;
+        }
+        if(component.types.includes('locality')) {
+          hidden_input_val.city = component.long_name;
+        }
+        if(component.types.includes('country')) {
+          hidden_input_val.country = component.long_name;
+        }
+      }
+
       that.$hidden_input.val( JSON.stringify( hidden_input_val ) );
     } );
   }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -58,6 +58,8 @@ class TwigExtension extends AbstractExtension
                 'lat' => null,
                 'long' => null,
                 'zoom' => null,
+                'zipCode' => null,
+                'city' => null
             ];
         }
 

--- a/templates/geolocation.html.twig
+++ b/templates/geolocation.html.twig
@@ -64,7 +64,8 @@
     <button type="button" class="btn btn-secondary js-zoom-gmap-in {{ zoom_btn_class }}">Zoom in</button>
     <button type="button" class="btn btn-secondary js-zoom-gmap-out {{ zoom_btn_class }}">Zoom out</button>
 
-    <input type="hidden" class="js-geolocation-val" name="{{ name }}" value="{{ value }}"/>
+    {% set restrictions = field.definition.has('autocompleteOptions') ? field.definition.get('autocompleteOptions') : [] %}
+    <input type="hidden" data-autocomplete-options="{{ restrictions|json_encode }}" class="js-geolocation-val" name="{{ name }}" value="{{ value }}"/>
 
     {# If values are already saved, build the Google Map Query #}
     {% if parsed_value.selected == "search" %}
@@ -97,5 +98,4 @@
 
     {#    {{ dump(geolocation_settings()) }}#}
   </div>
-
 {% endblock %}


### PR DESCRIPTION
According with @LordSimal , i have add some features:

- For autocomplete field: 
    - Possibility to add geocoding restriction in field options
    - Save city, zip code and country in location field
- For Lat, Lng fields: 
    - Adding geocoder in order to save city, zip code and country in location field 

If needed feel you free to comment or review this PR

Thanks to @LordSimal 