### PR TITLE
Initialise geolocation fields when duplicating content

### DIFF
--- a/src/GeolocationInjectorWidget.php
+++ b/src/GeolocationInjectorWidget.php
@@ -25,7 +25,7 @@ class GeolocationInjectorWidget extends BaseWidget implements TwigAwareInterface
     {
         $request = $this->getExtension()->getRequest();
         // Only produce output when editing or creating a Record, with GET method.
-        if (! in_array($request->get('_route'), ['bolt_content_edit', 'bolt_content_new'], true) ||
+        if (! in_array($request->get('_route'), ['bolt_content_edit', 'bolt_content_new', 'bolt_content_duplicate'], true) ||
             ($this->getExtension()->getRequest()->getMethod() !== 'GET')) {
             return null;
         }


### PR DESCRIPTION
Fixes bolt/core#2414 for geolocation