### PR TITLE
Added the parameter resolver to the config initialization

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,3 @@
 # Settings for Bolt Geolocation Field
 default:
-    apikey: "<my-api-key>"
+    apikey: "<my-api-key>" # or use '%bolt.google_maps_key%' (the google_maps_key parameter needs to be added to the config.yaml)

--- a/src/GeolocationConfig.php
+++ b/src/GeolocationConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Geolocation;
 
 use Bolt\Extension\ExtensionRegistry;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class GeolocationConfig
@@ -15,10 +16,14 @@ class GeolocationConfig
     /** @var CsrfTokenManagerInterface */
     private $csrfTokenManager;
 
-    public function __construct(ExtensionRegistry $registry, CsrfTokenManagerInterface $csrfTokenManager)
+    /** @var ParameterBagInterface */
+    private $parameterBag;
+
+    public function __construct(ExtensionRegistry $registry, CsrfTokenManagerInterface $csrfTokenManager, ParameterBagInterface $parameterBag)
     {
         $this->registry = $registry;
         $this->csrfTokenManager = $csrfTokenManager;
+        $this->parameterBag = $parameterBag;
     }
 
     /**
@@ -29,8 +34,10 @@ class GeolocationConfig
     public function getConfig(): array
     {
         $extension = $this->registry->getExtension(Extension::class);
+        $config = $extension->getConfig()['default'];
+        $resolvedConfig = $this->parameterBag->resolveValue($config);
 
-        return array_merge($this->getDefaults(), $extension->getConfig()['default']);
+        return array_merge($this->getDefaults(), $resolvedConfig);
     }
 
     /**


### PR DESCRIPTION
This allows users to add a parameter to the bolt `config.yaml`, which may look like this: 

`google_maps_key: '%env(GOOGLE_MAPS_KEY)%'`
