### PR TITLE
Fixes issue #13

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,4 @@
 # Settings for Bolt Geolocation Field
 default:
     apikey: "<my-api-key>" # or use '%bolt.google_maps_key%' (the google_maps_key parameter needs to be added to the config.yaml)
-    language: '%locale%'
+    locale: '%locale%'


### PR DESCRIPTION
### Description
Changes config key from `language` to `locale` in bolt-geolocation YAML configuration.

The configuration previously used:
```yaml
language: '%locale%'
```
This has been updated to:
```yaml
locale: '%locale%'
```
### Reason for Change
The `language` key was not being called in the templates which caused a fatal error

```html
<script src="https://maps.googleapis.com/maps/api/js?language={{ config.locale }}" ...
```

### Impact
- There are no breaking changes if the configuration is adjusted accordingly.
--- 