### PR TITLE
Feat: load map asynchronously

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,4 @@
 # Settings for Bolt Geolocation Field
 default:
     apikey: "<my-api-key>" # or use '%bolt.google_maps_key%' (the google_maps_key parameter needs to be added to the config.yaml)
-    language: '%locale%'
+    locale: '%locale%'

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -4,6 +4,6 @@
 {% set config = geolocation_settings() | geolocation_decode_json %}
 
 <script
-  src="https://maps.googleapis.com/maps/api/js?key={{ config.apikey }}&language={{ config.locale }}&callback=gmapCallback&libraries=places&v=weekly"
-  defer
+  src="https://maps.googleapis.com/maps/api/js?key={{ config.apikey }}&loading=async&language={{ config.locale }}&callback=gmapCallback&libraries=places&v=weekly"
+  async
 ></script>


### PR DESCRIPTION
This feature is made in response to a console warning suggesting to use async for optimal performance 

### Reference
[Add a script tag](https://developers.google.com/maps/documentation/javascript/load-maps-js-api#add_a_script_tag)
